### PR TITLE
CDCG-39- Centralize the use of project colors and themes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,14 +10,14 @@ import RescheduleAppointment from './pages/appointments/RescheduleAppointment';
 import SummaryAppointment from './pages/appointments/SummaryAppointment';
 import UnAuthorized from './pages/errors/UnAuthorized';
 import NotFound from './pages/errors/NotFound';
-import { SECONDARY_COLOR } from './utils/ConstantsColors';
+import { PRIMARY_COLOR } from './utils/ConstantsColors';
 
 const App = () => {
   return (
     <ConfigProvider
       theme={{
         token: {
-          colorPrimary: SECONDARY_COLOR,
+          colorPrimary: PRIMARY_COLOR,
         }
       }}>
       <Routes>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,12 +10,14 @@ import RescheduleAppointment from './pages/appointments/RescheduleAppointment';
 import SummaryAppointment from './pages/appointments/SummaryAppointment';
 import UnAuthorized from './pages/errors/UnAuthorized';
 import NotFound from './pages/errors/NotFound';
+import { SECONDARY_COLOR } from './utils/ConstantsColors';
+
 const App = () => {
   return (
     <ConfigProvider
       theme={{
         token: {
-          colorPrimary: '#1e40af',
+          colorPrimary: SECONDARY_COLOR,
         }
       }}>
       <Routes>

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -81,10 +81,10 @@ const Login = () => {
                     {/* Form */}
                     <div className="sm:w-1/2 px-8 flex flex-col">
                         <div className="text-left font-bold">
-                            <span className="text-action text-blue-800">{Strings.cDentalCare}</span> {Strings.group}
+                            <span className="text-action text-secondary">{Strings.cDentalCare}</span> {Strings.group}
                         </div>
                         <div className="flex flex-col items-center justify-center text-center mb-12 mt-4">
-                            <h2 className="text-2xl font-bold text-blue-800 mb-2 w-full mt-4">
+                            <h2 className="text-2xl font-bold text-secondary mb-2 w-full mt-4">
                                 {Strings.login}
                             </h2>
                             <div className="border-2 w-10 border-blue-800 inline-block mb-4"></div>

--- a/src/pages/branchoffice/schedules/SchedulesBranchOffice.tsx
+++ b/src/pages/branchoffice/schedules/SchedulesBranchOffice.tsx
@@ -77,8 +77,8 @@ const SchedulesBranchOffice = () => {
                         {value.employees.length == 0 && <span className="text text-xs text-gray-600">{Strings.emptyDentist}</span>}
                         {value.employees.map((employee: Employee, index: number) =>
                             <div key={index} className="flex justify-between gap-6 m-2">
-                                <span  className="text cursor-pointer text-xs text-blue-800">{buildEmployeeName(employee)}</span>
-                                <span onClick={() => handleDeleteScheduleDentist(employee.id,value.key)} className="text text-xs text-red-500 cursor-pointer">Eliminar dentista</span>
+                                <span  className="text cursor-pointer text-xs text-list1">{buildEmployeeName(employee)}</span>
+                                <span onClick={() => handleDeleteScheduleDentist(employee.id,value.key)} className="text text-xs text-list2 cursor-pointer">Eliminar dentista</span>
                             </div>
                         )}
                     </div>

--- a/src/pages/components/BackArrow.tsx
+++ b/src/pages/components/BackArrow.tsx
@@ -6,7 +6,7 @@ const BackArrow = () => {
     const navigate = useNavigate();
 
     return (
-        <div onClick={() => navigate(-1)} className="flex flex-row items-center align-baseline gap-2 text-blue-800 cursor-pointer mb-4">
+        <div onClick={() => navigate(-1)} className="flex flex-row items-center align-baseline gap-2 text-secondary cursor-pointer mb-4">
             <RiArrowLeftSLine size={24} />
             <span className="text text-sm">{Strings.return}</span>
         </div>

--- a/src/pages/components/Sidebar.tsx
+++ b/src/pages/components/Sidebar.tsx
@@ -2,7 +2,7 @@ import { Menu, MenuProps } from "antd";
 import Sider from "antd/es/layout/Sider";
 import { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
-import { PRIMARY_COLOR } from '../../utils/ConstantsColors';
+import { SECONDARY_COLOR } from '../../utils/ConstantsColors';
 
 export type MenuItem = Required<MenuProps>['items'][number];
 
@@ -42,7 +42,7 @@ const Sidebar = ({ items, collapsed }: SidebarProps) => {
     }
 
     const menuStyle = { 
-        backgroundColor: PRIMARY_COLOR,
+        backgroundColor: SECONDARY_COLOR,
     };
 
     return (

--- a/src/pages/components/Sidebar.tsx
+++ b/src/pages/components/Sidebar.tsx
@@ -2,6 +2,7 @@ import { Menu, MenuProps } from "antd";
 import Sider from "antd/es/layout/Sider";
 import { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
+import { PRIMARY_COLOR } from '../../utils/ConstantsColors';
 
 export type MenuItem = Required<MenuProps>['items'][number];
 
@@ -41,7 +42,7 @@ const Sidebar = ({ items, collapsed }: SidebarProps) => {
     }
 
     const menuStyle = { 
-        backgroundColor: '#001529',
+        backgroundColor: PRIMARY_COLOR,
     };
 
     return (

--- a/src/pages/components/Sidebar.tsx
+++ b/src/pages/components/Sidebar.tsx
@@ -40,8 +40,12 @@ const Sidebar = ({ items, collapsed }: SidebarProps) => {
         navigate(data.key);
     }
 
+    const menuStyle = { 
+        backgroundColor: '#001529',
+    };
+
     return (
-        <Sider className="layout-content" breakpoint="lg"  trigger={null} collapsible collapsed={collapsed}>
+        <Sider className="layout-content" breakpoint="lg"  trigger={null} collapsible collapsed={collapsed} style={menuStyle}>
             <div className="flex w-full items-center justify-center flex-col mb-6 mt-4 flex-wrap" >
                 <img
                     className={`object-cover ${collapsed ? ' w-8' : ' w-20'} transition-all`}
@@ -55,6 +59,7 @@ const Sidebar = ({ items, collapsed }: SidebarProps) => {
                 onClick={handleOnClick}
                 selectedKeys={[selectedPath]}
                 items={items}
+                style={menuStyle}
             />
         </Sider>
     );

--- a/src/utils/ConstantsColors.ts
+++ b/src/utils/ConstantsColors.ts
@@ -1,2 +1,2 @@
-export const PRIMARY_COLOR = '#001529';
-export const SECONDARY_COLOR = '#1e40af';
+export const PRIMARY_COLOR = '#1e40af';
+export const SECONDARY_COLOR = '#001529';

--- a/src/utils/ConstantsColors.ts
+++ b/src/utils/ConstantsColors.ts
@@ -1,0 +1,2 @@
+export const PRIMARY_COLOR = '#001529';
+export const SECONDARY_COLOR = '#1e40af';

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,14 +1,21 @@
-/** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        primary: '#001529',
+        secondary: '#1e40af',
+        list1: '#0047cc',
+        list2: '#e3342f',
+        textAside: '#ffffff'
+      },
+    },
   },
   plugins: [],
   corePlugins: {
     preflight: false,
-  }
-}
+  },
+};


### PR DESCRIPTION
### Feature / Bug Description
No se tenian centralizados los colores en caso de que se quisieran cambiar los colores del proyecto.

### Solution
Centralizar los colores con el uso de tailwind.config.js (para pequeños textos como los del login y el backArrow) y aplicar un style al theme de ant design para que en caso de querer cambiar los colores no se tenga que estar actualizando varios archivos.

### Notes
Add some notes

### Tickets
[CDCG-39T](https://cdentalcaregroup.atlassian.net/browse/)

![centralizado de colores1](https://github.com/cDentalCareGroup/web-cdentalcaregroup/assets/83984948/38f10d8e-a5e8-4f66-9388-ec11a554bc56)
![centralizado de colores2](https://github.com/cDentalCareGroup/web-cdentalcaregroup/assets/83984948/4a4711a2-207c-43f0-aecd-09c7712334f9)
![centralizado de colores3](https://github.com/cDentalCareGroup/web-cdentalcaregroup/assets/83984948/176c5b39-edf4-4e12-8c32-018a6bef8692)
![centralizado de colores4](https://github.com/cDentalCareGroup/web-cdentalcaregroup/assets/83984948/1cc40de8-8866-47ba-b3b4-f98d03e024d8)
![centralizado de colores5](https://github.com/cDentalCareGroup/web-cdentalcaregroup/assets/83984948/4552391e-c4a9-4eb0-9b73-74cfb2e73942)
![centralizado de colores6](https://github.com/cDentalCareGroup/web-cdentalcaregroup/assets/83984948/01a6b571-5af5-41a1-a1ad-593f6ebdaead)


### Screenshots / Screencasts
Provide screenshots or screencasts demoing your changes. 200px width is a good default for most screenshots.
e.g. <img width="200" alt="screenshot" src="...">
