### PR TITLE
CDCG-55-Add new test module for appointments

### DIFF
--- a/src/pages/appointmentsTest/AppointmentsTest.tsx
+++ b/src/pages/appointmentsTest/AppointmentsTest.tsx
@@ -1,0 +1,27 @@
+import LayoutCard from "../layouts/LayoutCard";
+import Strings from "../../utils/Strings";
+import { UserRoles } from "../../utils/Extensions";
+
+
+interface AppointmentsProps {
+    rol: UserRoles
+}
+
+const AppointmentsTest = (props: AppointmentsProps) => {
+   
+
+
+    return (
+        <LayoutCard
+		  title={Strings.appointmentsTest}
+		  isLoading={false}
+		  content={
+			<div className="flex flex-col">
+
+            </div>
+		  }
+		/>
+    );
+}
+
+export default AppointmentsTest;

--- a/src/pages/routes/Routes.tsx
+++ b/src/pages/routes/Routes.tsx
@@ -42,6 +42,7 @@ import Origins from '../origins/Origins';
 import FormAvailableTimes from '../schedules/FormAvailableTimes';
 import Organizations from '../organization/Organizations';
 import Reports from '../reports/Reports';
+import AppointmentsTest from '../appointmentsTest/AppointmentsTest';
 
 export class Route {
 	label: string;
@@ -263,6 +264,13 @@ const receptionistDetails = new Route(
 	<AppointmentInfo rol={UserRoles.RECEPTIONIST} />,
 	<RiCalendar2Line />
 );
+const receptionistAppointmentTest = new Route(
+	'Citas Test',
+	'appointmentTest',
+	'/receptionist/appointmentsTest/',
+	<AppointmentsTest rol={UserRoles.RECEPTIONIST} />,
+	<RiCalendar2Line />
+);
 const receptionistRegisterPatients = new Route(
 	'RegistroPacientes',
 	'patientsRegister',
@@ -400,6 +408,7 @@ const adminRoutes: Route[] = [
 const receptionistRoutes: Route[] = [
 	receptionistAppointments,
 	receptionistDetails,
+	receptionistAppointmentTest,
 	receptionistPatients,
 	receptionistRegisterPatients,
 	receptionistPatientsInfo,
@@ -570,6 +579,11 @@ const receptionistRoutesToMenuOptions = (): ItemType[] => {
 					receptionistAppointments.label,
 					receptionistAppointments.fullPath,
 					receptionistAppointments.icon
+				),
+				getItem(
+					receptionistAppointmentTest.label,
+					receptionistAppointmentTest.fullPath,
+					receptionistAppointmentTest.icon
 				),
 				getItem(
 					receptionistPatients.label,

--- a/src/utils/Strings.ts
+++ b/src/utils/Strings.ts
@@ -70,6 +70,7 @@ class Strings {
     static status = "Estatus"
     static appointment = "Cita"
     static appointments = "Citas"
+    static appointmentsTest ="Citas Test";
     static service = "Servicio";
     static services = "Servicios";
     static patientId = "Folio de paciente"


### PR DESCRIPTION
### Feature / Bug Description
For the new appointment design it is necessary to create a new section for testing to verify operation.

### Solution
create a new test appointments section for the receptionists role

### Notes
Add some notes

### Tickets
[CDCG-55](https://cdentalcaregroup.atlassian.net/browse/)

### Screenshots / Screencasts
Provide screenshots or screencasts demoing your changes. 200px width is a good default for most screenshots.
e.g. <img width="200" alt="screenshot" src="...">
![image](https://github.com/cDentalCareGroup/web-cdentalcaregroup/assets/83984948/4b61764f-3dce-4fcd-98b1-a8213721c58c)



[CDCG-55]: https://cdentalcaregroup.atlassian.net/browse/CDCG-55?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ